### PR TITLE
Switch numerical scaling to relative

### DIFF
--- a/tests/test_large.py
+++ b/tests/test_large.py
@@ -62,7 +62,7 @@ class TestCORDAlarge:
         assert len(include) > 3
         rec = opt.cobra_model("reconstruction")
         sol = rec.optimize()
-        assert sol.f > 1
+        assert sol.objective_value > 1
 
     @pytest.mark.parametrize("solver", solvers)
     def test_benchmark_large(self, large, benchmark, solver):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,19 +31,6 @@ class TestConf:
 
 class TestMisc:
 
-    def test_remove_breaks(self):
-        model = Model("test model")
-        A = Metabolite("A")
-        r = Reaction("r")
-        r.add_metabolites({A: -1})
-        r.lower_bound = -1000
-        r.upper_bound = 1000
-        model.add_reaction(r)
-        convert_to_irreversible(model)
-        model.remove_reactions(["r"])
-        with pytest.raises(KeyError):
-            revert_to_reversible(model)
-
     def test_cemet(self):
         model = test_model()
         assert len(model.reactions) == 60


### PR DESCRIPTION
Now uses relative scaling, ergo `bound * a` where a >> 1 instead of just assigning a very large bound. This should maintain a bound structure that is more similar to the original model and lead to less blocked reactions in the reconstruction.

Still requires validation.